### PR TITLE
Microsoft config: remove client secret, use custom redirect uri

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -43,6 +43,7 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="net.openid.appauth.demo"/>
                 <data android:scheme="com.googleusercontent.apps.533526602309-6g5u7a7gk5gaevtei81mt8c5aokbeklv"/>
+                <data android:scheme="msalfb7f3460-68b6-48f9-a272-71e1ebf39cd2"/>
             </intent-filter>
 
             <!--

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ For further explanation, read the section on "Why is this app bad?" below.
 This app demonstrate the use of the
 [AppAuth for Android](https://github.com/openid/AppAuth-Android/)
 library to interact with four identity providers (IDPs): Facebook, GitHub,
-Google and Microsoft. While Google supports the current best-practices for
+Google and Microsoft. While Google and Microsoft support the current best-practices for
 OAuth2 from mobile devices (specifically, public clients and PKCE), the other
 providers do not:
 
-- All require the use of client secrets in order
+- Github and Facebook require the use of client secrets in order
   to acquire a refresh token. The use of the implicit flow to acquire
   short lived access tokens is generally unacceptable for mobile apps, as
   frequent usage of custom tabs to acquire new access tokens will disrupt the
   user experience.
 
-- All require that the redirect URI be an https URL. Prior to Android M, this
+- Github and Facebook require that the redirect URI be an https URL. Prior to Android M, this
   would require the use of an "interstitial" web page to be used that could
   collect the response of the authorization request and forward it to the
   app via a custom scheme URI. With Android M and above this is less of an
@@ -58,7 +58,7 @@ This app is a good example of what *not* to do when using AppAuth for Android:
 
 *DO NOT DO ANY OF THESE* in your own apps. As things stand at the time of
 writing, one should not use AppAuth for Android to integrate _directly_ with
-Facebook, GitHub or Microsoft. Once these providers support the recommendations
+Facebook or GitHub. Once these providers support the recommendations
 of [OAuth 2.0 for Native Apps](https://tools.ietf.org/html/draft-wdenniss-oauth-native-apps)
 then that will change.
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }

--- a/res/values/idp_configs.xml
+++ b/res/values/idp_configs.xml
@@ -23,15 +23,15 @@
     -->
     <string name="google_auth_redirect_uri" translatable="false">com.googleusercontent.apps.533526602309-6g5u7a7gk5gaevtei81mt8c5aokbeklv:/oauth2redirect</string>
 
-    <bool name="facebook_enabled" translatable="false">true</bool>
+    <bool name="facebook_enabled">true</bool>
     <string name="facebook_client_id" translatable="false">1493898367579297</string>
     <string name="facebook_client_secret" translatable="false">c29fdd53c851356337d1bcc3139b5e27</string>
 
     <bool name="microsoft_enabled">true</bool>
-    <string name="microsoft_client_id">fb7f3460-68b6-48f9-a272-71e1ebf39cd2</string>
-    <string name="microsoft_client_secret" translatable="false">tJA4kMt79nbXHiJ8DUywQvV</string>
+    <string name="microsoft_client_id" translatable="false">fb7f3460-68b6-48f9-a272-71e1ebf39cd2</string>
+    <string name="microsoft_auth_redirect_uri" translatable="false">msalfb7f3460-68b6-48f9-a272-71e1ebf39cd2://auth</string>
 
-    <bool name="github_enabled" translatable="false">true</bool>
-    <string name="github_client_id">30890f8e4ae2a189c94f</string>
+    <bool name="github_enabled">true</bool>
+    <string name="github_client_id" translatable="false">30890f8e4ae2a189c94f</string>
     <string name="github_client_secret" translatable="false">02f23ebb9de764cbbfda9aeb8c0ebfdece534cf8</string>
 </resources>

--- a/res/values/idp_configs_optional.xml
+++ b/res/values/idp_configs_optional.xml
@@ -18,8 +18,7 @@
 
     <string name="microsoft_name">Microsoft</string>
     <string name="microsoft_discovery_uri" translatable="false">https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration</string>
-    <string name="microsoft_auth_redirect_uri" translatable="false">https://appauth.demo-app.io/oauth2redirect</string>
-    <string name="microsoft_scope_string">openid profile email offline_access</string>
+    <string name="microsoft_scope_string" translatable="false">openid profile email offline_access</string>
 
     <string name="github_name">Github</string>
     <string name="github_auth_endpoint" translatable="false">https://github.com/login/oauth/authorize</string>

--- a/src/net/openid/appauthdemo/moreidps/IdentityProvider.java
+++ b/src/net/openid/appauthdemo/moreidps/IdentityProvider.java
@@ -86,7 +86,7 @@ class IdentityProvider {
             NOT_SPECIFIED,
             NOT_SPECIFIED,
             R.string.microsoft_client_id,
-            R.string.microsoft_client_secret,
+            NOT_SPECIFIED, // client secret is not required for Microsoft
             R.string.microsoft_auth_redirect_uri,
             R.string.microsoft_scope_string,
             R.drawable.btn_microsoft,


### PR DESCRIPTION
For this to work you need to go to https://apps.dev.microsoft.com/#/application/fb7f3460-68b6-48f9-a272-71e1ebf39cd2 and enable the custom redirect uri in the Platforms -> Native application section. The PR uses the default one which is `msal<client id>://auth`.

closes #1 

